### PR TITLE
Fast fail if compilation fails

### DIFF
--- a/run-services.sh
+++ b/run-services.sh
@@ -8,6 +8,8 @@ else
     ./mvnw install
 fi
 
-docker-compose down --remove-orphans
-docker-compose build --no-cache
-docker-compose up
+if [[ $? -eq 0 ]]; then
+  docker-compose down --remove-orphans
+  docker-compose build --no-cache
+  docker-compose up
+fi


### PR DESCRIPTION
Minor adjustment to run-services script to fail if the maven install fails, so you dont have to spam cancel if theres errors to stop docker starting.