### PR TITLE
Fix infinite stats endpoint call and buttons issue

### DIFF
--- a/backend/src/main/java/com/vax/warden/model/Vaccination.java
+++ b/backend/src/main/java/com/vax/warden/model/Vaccination.java
@@ -30,7 +30,11 @@ public class Vaccination implements Serializable {
     @Temporal(TemporalType.TIMESTAMP)
     private Date secondAppointment;
 
+    @Enumerated(EnumType.STRING)
     private VaccineType firstVaccineType;
+
+    @Enumerated(EnumType.STRING)
     private VaccineType secondVaccineType;
+
     private Integer dosesReceived = 0;
 }


### PR DESCRIPTION
- Fix infinite GET (200) call to `/statistics/user` after vaccination appointment is booked.
- Hide `ageGroup` stat in Home
- Fix button/text display in Home