### PR TITLE
Https support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 HELP.md
 target/
+backend/src/main/resources/cert.pfx
+frontend/.cert
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ COVID-19 vaccine registration system using Java, Spring Boot and React.js, devel
 
 - Docker
 - JDK >= 11
+- [mkcert](https://github.com/FiloSottile/mkcert), make sure to run `mkcert -install` after installation
+- [openssl](https://github.com/openssl/openssl)
 - **OS: macOS or Linux** (including Windows Subsystem for Linux 2). Native Windows does not support [tmpfs mounts](https://docs.docker.com/storage/tmpfs/) used to speed up the Docker container set-up. If running on Windows, the boot time will be greater, but it is possible to comment out the `tmpfs: - /var/lib/mysql` lines in [docker-compose.yml](./docker-compose.yml), and also change the sleep time from 5 to 35 seconds in [backend/Dockerfile](./backend/Dockerfile).
 
+> 
 ## Getting Started
 
 - Running with `docker-compose`. The `--clean` flag is optional (for a `mvn clean install`).
@@ -16,7 +19,7 @@ COVID-19 vaccine registration system using Java, Spring Boot and React.js, devel
   ./run-services.sh --clean
   ```
 
-- Navigate to [localhost](http://localhost) in a browser to view the frontend after the Spring Boot application is running (check `docker-compose` logs). _Note_: If unable to access localhost, find the container IP address as shown below and navigate to `http://<IP>` instead.
+- Navigate to [localhost](https://localhost/) in a browser to view the frontend after the Spring Boot application is running (check `docker-compose` logs). _Note_: If unable to access localhost, find the container IP address as shown below and navigate to `https://<IP>` instead.
 
   ```bash
   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vax-warden-frontend

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ COVID-19 vaccine registration system using Java, Spring Boot and React.js, devel
 - Docker
 - JDK >= 11
 - [mkcert](https://github.com/FiloSottile/mkcert), make sure to run `mkcert -install` after installation
+- [certutil](https://firefox-source-docs.mozilla.org/security/nss/legacy/tools/nss_tools_certutil/index.html) for Firefox support
 - [openssl](https://github.com/openssl/openssl)
 - **OS: macOS or Linux** (including Windows Subsystem for Linux 2). Native Windows does not support [tmpfs mounts](https://docs.docker.com/storage/tmpfs/) used to speed up the Docker container set-up. If running on Windows, the boot time will be greater, but it is possible to comment out the `tmpfs: - /var/lib/mysql` lines in [docker-compose.yml](./docker-compose.yml), and also change the sleep time from 5 to 35 seconds in [backend/Dockerfile](./backend/Dockerfile).
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,11 @@ server:
   error:
     include-message: always
     include-binding-errors: always
+  ssl:
+    key-store-type: PKCS12
+    key-store: classpath:cert.pfx
+    key-store-password: vax-warden
+    enabled: true
 
 spring:
   application:

--- a/backend/src/main/resources/http/admin/list-users.http
+++ b/backend/src/main/resources/http/admin/list-users.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/admin/user/list
+GET https://localhost:8080/admin/user/list

--- a/backend/src/main/resources/http/admin/update-user-vaccination.http
+++ b/backend/src/main/resources/http/admin/update-user-vaccination.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/admin/user/vaccination/1
+POST https://localhost:8080/admin/user/vaccination/1
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/auth/login.http
+++ b/backend/src/main/resources/http/auth/login.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/auth/login
+POST https://localhost:8080/auth/login
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/auth/register-user.http
+++ b/backend/src/main/resources/http/auth/register-user.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/auth/register
+POST https://localhost:8080/auth/register
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/forum/create-post.http
+++ b/backend/src/main/resources/http/forum/create-post.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/forum/post
+POST https://localhost:8080/forum/post
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/forum/create-reply.http
+++ b/backend/src/main/resources/http/forum/create-reply.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/forum/reply
+POST https://localhost:8080/forum/reply
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/forum/list-posts.http
+++ b/backend/src/main/resources/http/forum/list-posts.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/forum/list
+GET https://localhost:8080/forum/list

--- a/backend/src/main/resources/http/statistics/get-aggregated-stats.http
+++ b/backend/src/main/resources/http/statistics/get-aggregated-stats.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/statistics/all
+GET https://localhost:8080/statistics/all

--- a/backend/src/main/resources/http/statistics/get-user-stats.http
+++ b/backend/src/main/resources/http/statistics/get-user-stats.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/statistics/user
+GET https://localhost:8080/statistics/user

--- a/backend/src/main/resources/http/vaccination/book-first-dose.http
+++ b/backend/src/main/resources/http/vaccination/book-first-dose.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/vaccination/book
+POST https://localhost:8080/vaccination/book
 Content-Type: application/json
 
 {

--- a/backend/src/main/resources/http/vaccination/cancel-booking.http
+++ b/backend/src/main/resources/http/vaccination/cancel-booking.http
@@ -1,1 +1,1 @@
-POST http://localhost:8080/vaccination/cancel
+POST https://localhost:8080/vaccination/cancel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,6 @@ services:
         - BACKEND_PORT=8080
     container_name: vax-warden-frontend
     ports:
-      - "80:3000"
+      - "443:3000"
     depends_on:
       - backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "HTTPS=true SSL_CRT_FILE=./.cert/cert.pem SSL_KEY_FILE=./.cert/key.pem react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/src/client/constants.ts
+++ b/frontend/src/client/constants.ts
@@ -1,4 +1,4 @@
 const BACKEND_HOST = process.env.REACT_APP_BACKEND_HOST || "localhost";
 const BACKEND_PORT = process.env.REACT_APP_BACKEND_PORT || 8080;
 
-export const BASE_URL = `http://${BACKEND_HOST}:${BACKEND_PORT}`;
+export const BASE_URL = `https://${BACKEND_HOST}:${BACKEND_PORT}`;

--- a/run-services.sh
+++ b/run-services.sh
@@ -2,6 +2,13 @@
 
 num_args=$#
 
+mkcert -install
+mkdir ./frontend/.cert
+# generate frontend certificate
+mkcert -key-file ./frontend/.cert/key.pem -cert-file ./frontend/.cert/cert.pem "localhost"
+# generate backend p12 certificate from frontend certificate
+openssl pkcs12 -inkey ./frontend/.cert/key.pem -in ./frontend/.cert/cert.pem -export -passout pass:vax-warden -out ./backend/src/main/resources/cert.pfx
+
 if [[ $num_args -eq 1 && "$1" == "--clean" ]]; then
     ./mvnw clean install
 else


### PR DESCRIPTION
Added https support
- change http to https in http files
- frontend and backend secured using certificate generated using `mkcert`, both share same certificate
- frontend now hosted at [https://localhost/](https://localhost/)
- update `run-services.sh` to auto generate certificates for frontend and backend
- update `README.md` with extra dependencies

closes #64 